### PR TITLE
Add information about republishing messages

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,6 +221,10 @@ Path to the private key file.
 
 When true, will skip certificate verification. For use only with self-signed certs.
 
+`republishMessages` - _Type_: boolean; _Default_: true
+
+When true, all transactions that are received from other nodes are republished to this node's stream. When pub/sub routes are not fully connected between all nodes, this ensures that messages are routed to all nodes through intermediate nodes. This also ensures that all writes, whether local or remote, are written to the NATS transaction log. However, there is additional overhead with republishing, and setting this is to false can provide better clustering performance. When false, you need to ensure all pub/sub routes are fully connected between every node to every other node, and be aware that the NATS transaction log will only consist of local writes.  
+
 `verify` - _Type_: boolean; _Default_: true
 
 When true, hub server will verify client certificate using the CA certificate.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -223,7 +223,7 @@ When true, will skip certificate verification. For use only with self-signed cer
 
 `republishMessages` - _Type_: boolean; _Default_: true
 
-When true, all transactions that are received from other nodes are republished to this node's stream. When pub/sub routes are not fully connected between all nodes, this ensures that messages are routed to all nodes through intermediate nodes. This also ensures that all writes, whether local or remote, are written to the NATS transaction log. However, there is additional overhead with republishing, and setting this is to false can provide better clustering performance. When false, you need to ensure all pub/sub routes are fully connected between every node to every other node, and be aware that the NATS transaction log will only consist of local writes.  
+When true, all transactions that are received from other nodes are republished to this node's stream. When subscriptions are not fully connected between all nodes, this ensures that messages are routed to all nodes through intermediate nodes. This also ensures that all writes, whether local or remote, are written to the NATS transaction log. However, there is additional overhead with republishing, and setting this is to false can provide better data replication performance. When false, you need to ensure all subscriptions are fully connected between every node to every other node, and be aware that the NATS transaction log will only consist of local writes.  
 
 `verify` - _Type_: boolean; _Default_: true
 


### PR DESCRIPTION
This updates the configuration documentation for the new setting. Presently we are only treating this as a potential option for clustering performance issues, but if further testing reveals more of a need for this, could potentially add the clustering instructions themselves.