### PR TITLE
Switch the release entry page to an overview instead of a dog picture

### DIFF
--- a/docs/technical-details/release-notes/4.tucker/README.md
+++ b/docs/technical-details/release-notes/4.tucker/README.md
@@ -1,7 +1,25 @@
 # HarperDB Tucker (Version 4)
 
-Did you know our release names are dedicated to employee pups? For our fourth release, we have Tucker.
+HarperDB version 4 ([Tucker release](./tucker.md)) represents major step forward in database technology. This release line has ground-breaking architectural advancements including:
 
-![picture of grey and white dog](../../../../images/dogs/tucker.png)
+## [4.0](./4.0.0.md)
+* New clustering technology that delivers robust, resilient and high-performance replication
+* Major storage improvements with highly-efficient adaptive-structure modified MessagePack format, with on-demand deserialization capabilities
 
-_G’day, I’m Tucker. My dad is David Cockerill, a software engineer here at HarperDB. I am a 3-year-old Labrador Husky mix. I love to protect my dad from all the squirrels and rabbits we have in our yard. I have very ticklish feet and love belly rubs!_
+## [4.1](./4.1.0.md)
+* New streaming iterators mechanism that allows query results to be delivered to clients _while_ querying results are being processed, for incredibly fast time-to-first-byte and concurrent processing/delivery
+* New thread-based concurrency model for more efficient resource usage
+
+## [4.2](./4.2.0.md)
+* New component architecture and Resource API for advanced, robust custom database application development
+* Real-time capabilites through MQTT, WebSockets, and Server-Sent Events
+* REST interface for intuitive, fast, and standards-compliant HTTP interaction
+* Native caching capabilities for high-performance cache scenarios
+* Clone node functionality
+
+## [4.3](./4.3.0.md)
+* Relationships, joins, and broad new querying capabilites for complex and nested conditions, sorting, joining, and selecting with significant query optimizations
+* More advanced transaction support for CRDTs and storage of large integers (with BigInt)
+* Better management with new upgraded local studio and new CLI features
+
+Did you know our release names are dedicated to employee pups? For our fourth release, [meet Tucker!](./tucker.md)

--- a/docs/technical-details/release-notes/4.tucker/tucker.md
+++ b/docs/technical-details/release-notes/4.tucker/tucker.md
@@ -1,0 +1,7 @@
+# HarperDB Tucker (Version 4)
+
+Did you know our release names are dedicated to employee pups? For our fourth release, we have Tucker.
+
+![picture of grey and white dog](../../../../images/dogs/tucker.png)
+
+_G’day, I’m Tucker. My dad is David Cockerill, a software engineer here at HarperDB. I am a 3-year-old Labrador Husky mix. I love to protect my dad from all the squirrels and rabbits we have in our yard. I have very ticklish feet and love belly rubs!_


### PR DESCRIPTION
As much as we all love David's dog, it would probably be much more useful for users to have an overview of our (v4) releases on the entry page (still preserving a dedicated "Tucker" page).