### PR TITLE
Add missing sys info attrs to ops utilities docs

### DIFF
--- a/docs/developers/operations-api/utilities.md
+++ b/docs/developers/operations-api/utilities.md
@@ -52,7 +52,7 @@ Returns detailed metrics on the host system.
 _Operation is restricted to super_user roles only_
 
 * operation _(required)_ - must always be `system_information`
-* attributes _(optional)_ - string array of top level attributes desired in the response, if no value is supplied all attributes will be returned. Available attributes are: ['system', 'time', 'cpu', 'memory', 'disk', 'network', 'harperdb_processes', 'table_size', 'replication']
+* attributes _(optional)_ - string array of top level attributes desired in the response, if no value is supplied all attributes will be returned. Available attributes are: ['system', 'time', 'cpu', 'memory', 'disk', 'network', 'harperdb_processes', 'table_size', 'metrics', 'threads', 'replication']
 
 ### Body
 ```json


### PR DESCRIPTION
I noticed a couple of the `system_information` attributes supported by [the code](https://github.com/HarperDB/harperdb/blob/716ce52f83d7a9bfbb018d63340aba6900c3a48a/utility/environment/systemInformation.js#L352-L386) weren't listed in here. This adds them.