### PR TITLE
document server properties

### DIFF
--- a/docs/technical-details/reference/globals.md
+++ b/docs/technical-details/reference/globals.md
@@ -294,7 +294,7 @@ Parameters:
 - **context** - [`OperationContext`](#operationcontext) - _optional_ - A context object relating to the specified operation
 - **authorize** - boolean - _optional_ - Indicate the operation should authorize the user or not. Defaults to `false`
 
-Returns a promise with the operation's response as per the [Operations API documentation](https://docs.harperdb.io/docs/developers/operations-api).
+Returns a `Promise` with the operation's response as per the [Operations API documentation](https://docs.harperdb.io/docs/developers/operations-api).
 
 ### `server.nodes`
 Returns an array of node objects registered in the cluster

--- a/docs/technical-details/reference/globals.md
+++ b/docs/technical-details/reference/globals.md
@@ -284,15 +284,15 @@ server.resources.getMatch('/NewResource/some-id');
 server.resources.getMatch('/NewResource/some-id', 'my-protocol');
 ```
 
-### `server.operation(operation: OperationRequestBody, context?: OperationContext, authorize?: boolean)`
+### `server.operation(operation: Object, context?: Object, authorize?: boolean)`
 
 Execute an operation from the [Operations API](https://docs.harperdb.io/docs/developers/operations-api)
 
 Parameters:
 
-- **operation** - [`OperationRequestBody`](#operationrequestbody) - Object matching desired operation's request body
-- **context** - [`OperationContext`](#operationcontext) - _optional_ - A context object relating to the specified operation
-- **authorize** - boolean - _optional_ - Indicate the operation should authorize the user or not. Defaults to `false`
+- **operation** - `Object` - Object matching desired operation's request body
+- **context** - `Object` - `{ username: string}` - _optional_ - The specified user
+- **authorize** - `boolean` - _optional_ - Indicate the operation should authorize the user or not. Defaults to `false`
 
 Returns a `Promise` with the operation's response as per the [Operations API documentation](https://docs.harperdb.io/docs/developers/operations-api).
 

--- a/docs/technical-details/reference/globals.md
+++ b/docs/technical-details/reference/globals.md
@@ -284,7 +284,8 @@ server.resources.getMatch('/NewResource/some-id');
 server.resources.getMatch('/NewResource/some-id', 'my-protocol');
 ```
 
-### `server.operation(operation, context, authorize?)`
+### `server.operation(operation: OperationRequestBody, context?: OperationContext, authorize?: boolean)`
+
 Execute an operation from the [Operations API](https://docs.harperdb.io/docs/developers/operations-api)
 
 Parameters:

--- a/docs/technical-details/reference/globals.md
+++ b/docs/technical-details/reference/globals.md
@@ -290,11 +290,9 @@ Execute an operation from the [Operations API](https://docs.harperdb.io/docs/dev
 
 Parameters:
 
-`operation`: Object matching desired operation's request body
-
-`context`: TODO ???
-
-`authorize`: TODO ???
+- **operation** - [`OperationRequestBody`](#operationrequestbody) - Object matching desired operation's request body
+- **context** - [`OperationContext`](#operationcontext) - _optional_ - A context object relating to the specified operation
+- **authorize** - boolean - _optional_ - Indicate the operation should authorize the user or not. Defaults to `false`
 
 Returns a promise with the operation's response as per the [Operations API documentation](https://docs.harperdb.io/docs/developers/operations-api).
 

--- a/docs/technical-details/reference/globals.md
+++ b/docs/technical-details/reference/globals.md
@@ -283,3 +283,25 @@ server.resources.getMatch('/NewResource/some-id');
 // or specify the export/protocol type, to allow it to be limited:
 server.resources.getMatch('/NewResource/some-id', 'my-protocol');
 ```
+
+### `server.operation(operation, context, authorize?)`
+Execute an operation from the [Operations API](https://docs.harperdb.io/docs/developers/operations-api)
+
+Parameters:
+
+`operation`: Object matching desired operation's request body
+
+`context`: TODO ???
+
+`authorize`: TODO ???
+
+Returns a promise with the operation's response as per the [Operations API documentation](https://docs.harperdb.io/docs/developers/operations-api).
+
+### `server.nodes`
+Returns an array of node objects registered in the cluster
+
+### `server.shards`
+Returns map of shard number to an array of its associated nodes
+
+### `server.hostname`
+Returns the hostname of the current node


### PR DESCRIPTION
Documents a few properties from the server global that were missing.

`operation()`
`nodes`
`shares`
`hostname`
