### PR TITLE
Fix old utilities urls

### DIFF
--- a/docs/administration/administration.md
+++ b/docs/administration/administration.md
@@ -19,7 +19,7 @@ Harper provides rapid horizontal scaling capabilities through [node cloning func
 Harper provides robust capabilities for analytics and observability to facilitate effective and informative monitoring:
 
 - Analytics provides statistics on usage, request counts, load, memory usage with historical tracking. The analytics data can be [accessed through querying](../technical-details/reference/analytics.md).
-- A large variety of real-time statistics about load, system information, database metrics, thread usage can be retrieved through the [`system_information` API](../developers/operations-api/utilities.md).
+- A large variety of real-time statistics about load, system information, database metrics, thread usage can be retrieved through the [`system_information` API](../developers/operations-api/system-operations.md).
 - Information about the current cluster configuration and status can be found in the [cluster APIs](../developers/operations-api/clustering.md).
 - Analytics and system information can easily be exported to Prometheus with our [Prometheus exporter component](https://github.com/HarperDB-Add-Ons/prometheus_exporter), making it easy visualize and monitor Harper with Graphana.
 

--- a/docs/administration/jobs.md
+++ b/docs/administration/jobs.md
@@ -20,11 +20,11 @@ Example job operations include:
 
 [import from s3](../developers/operations-api/bulk-operations.md#import-from-s3)
 
-[delete_records_before](../developers/operations-api/utilities.md#delete-records-before)
+[delete_records_before](../developers/operations-api/bulk-operations.md#delete-records-before)
 
-[export_local](../developers/operations-api/utilities.md#export-local)
+[export_local](../developers/operations-api/bulk-operations.md#export-local)
 
-[export_to_s3](../developers/operations-api/utilities.md#export-to-s3)
+[export_to_s3](../developers/operations-api/bulk-operations.md#export-to-s3)
 
 Example Response from a Job Operation
 

--- a/docs/deployments/configuration.md
+++ b/docs/deployments/configuration.md
@@ -12,7 +12,7 @@ The configuration elements in `harperdb-config.yaml` use camelcase, such as `ope
 
 To change a configuration value, edit the `harperdb-config.yaml` file and save any changes. **HarperDB must be restarted for changes to take effect.**
 
-Alternatively, all configuration values can also be modified using environment variables, command line arguments, or the operations API via the [`set_configuration` operation](../developers/operations-api/utilities.md#set-configuration).
+Alternatively, all configuration values can also be modified using environment variables, command line arguments, or the operations API via the [`set_configuration` operation](../developers/operations-api/configuration.md#set-configuration).
 
 For nested configuration elements, use underscores to represent parent-child relationships. When accessed this way, elements are case-insensitive.
 


### PR DESCRIPTION
Looks like I missed these when breaking up the operations-api/utilities.md doc