### PR TITLE
Update search conditions properties to new preferred values

### DIFF
--- a/docs/developers/operations-api/nosql-operations.md
+++ b/docs/developers/operations-api/nosql-operations.md
@@ -267,8 +267,11 @@ Returns data from a table for one or more matching conditions. This supports gro
 - `get_attributes` _(required)_ - define which attributes you want returned. Use `['*']` to return all attributes
 - `conditions` _(required)_ - the array of conditions objects, specified below, to filter by. Must include one or more object in the array that are a condition or a grouped set of conditions. A condition has the following properties:
   - `attribute` _(required)_ - the attribute you wish to search, can be any attribute
+  - `search_attribute` - deprecated in favor of `attribute`
   - `comparator` _(required)_ - the type of search to perform - `equals`, `contains`, `starts_with`, `ends_with`, `greater_than`, `greater_than_equal`, `less_than`, `less_than_equal`, `between`
+  - `search_type` - deprecated in favor of `comparator`
   - `value` _(required)_ - case-sensitive value you wish to search. If the `comparator` is `between` then use an array of two values to search between
+  - `search_value` - deprecated in favor of `value`
     Or a set of grouped conditions has the following properties:
   - `operator` _(optional)_ - the operator used between each condition - `and`, `or`. The default is `and`
   - `conditions` _(required)_ - the array of conditions objects as described above.

--- a/docs/developers/operations-api/nosql-operations.md
+++ b/docs/developers/operations-api/nosql-operations.md
@@ -266,9 +266,9 @@ Returns data from a table for one or more matching conditions. This supports gro
   - `next` _(optional)_ - This can define the next sort object that will be used to break ties for sorting when there are multiple records with the same value for the first attribute (follows the same structure as `sort`).
 - `get_attributes` _(required)_ - define which attributes you want returned. Use `['*']` to return all attributes
 - `conditions` _(required)_ - the array of conditions objects, specified below, to filter by. Must include one or more object in the array that are a condition or a grouped set of conditions. A condition has the following properties:
-  - `search_attribute` _(required)_ - the attribute you wish to search, can be any attribute
-  - `search_type` _(required)_ - the type of search to perform - `equals`, `contains`, `starts_with`, `ends_with`, `greater_than`, `greater_than_equal`, `less_than`, `less_than_equal`, `between`
-  - `search_value` _(required)_ - case-sensitive value you wish to search. If the `search_type` is `between` then use an array of two values to search between
+  - `attribute` _(required)_ - the attribute you wish to search, can be any attribute
+  - `comparator` _(required)_ - the type of search to perform - `equals`, `contains`, `starts_with`, `ends_with`, `greater_than`, `greater_than_equal`, `less_than`, `less_than_equal`, `between`
+  - `value` _(required)_ - case-sensitive value you wish to search. If the `comparator` is `between` then use an array of two values to search between
     Or a set of grouped conditions has the following properties:
   - `operator` _(optional)_ - the operator used between each condition - `and`, `or`. The default is `and`
   - `conditions` _(required)_ - the array of conditions objects as described above.
@@ -293,27 +293,27 @@ Returns data from a table for one or more matching conditions. This supports gro
 	"get_attributes": ["*"],
 	"conditions": [
 		{
-			"search_attribute": "age",
-			"search_type": "between",
-			"search_value": [5, 8]
+			"attribute": "age",
+			"comparator": "between",
+			"value": [5, 8]
 		},
 		{
-			"search_attribute": "weight_lbs",
-			"search_type": "greater_than",
-			"search_value": 40
+			"attribute": "weight_lbs",
+			"comparator": "greater_than",
+			"value": 40
 		},
 		{
 			"operator": "or",
 			"conditions": [
 				{
-					"search_attribute": "adorable",
-					"search_type": "equals",
-					"search_value": true
+					"attribute": "adorable",
+					"comparator": "equals",
+					"value": true
 				},
 				{
-					"search_attribute": "lovable",
-					"search_type": "equals",
-					"search_value": true
+					"attribute": "lovable",
+					"comparator": "equals",
+					"value": true
 				}
 			]
 		}

--- a/site/versioned_docs/version-4.6/developers/operations-api/nosql-operations.md
+++ b/site/versioned_docs/version-4.6/developers/operations-api/nosql-operations.md
@@ -266,9 +266,9 @@ Returns data from a table for one or more matching conditions. This supports gro
   - `next` _(optional)_ - This can define the next sort object that will be used to break ties for sorting when there are multiple records with the same value for the first attribute (follows the same structure as `sort`).
 - `get_attributes` _(required)_ - define which attributes you want returned. Use `['*']` to return all attributes
 - `conditions` _(required)_ - the array of conditions objects, specified below, to filter by. Must include one or more object in the array that are a condition or a grouped set of conditions. A condition has the following properties:
-  - `search_attribute` _(required)_ - the attribute you wish to search, can be any attribute
-  - `search_type` _(required)_ - the type of search to perform - `equals`, `contains`, `starts_with`, `ends_with`, `greater_than`, `greater_than_equal`, `less_than`, `less_than_equal`, `between`
-  - `search_value` _(required)_ - case-sensitive value you wish to search. If the `search_type` is `between` then use an array of two values to search between
+  - `attribute` _(required)_ - the attribute you wish to search, can be any attribute.
+  - `comparator` _(required)_ - the type of search to perform - `equals`, `contains`, `starts_with`, `ends_with`, `greater_than`, `greater_than_equal`, `less_than`, `less_than_equal`, `between`
+  - `value` _(required)_ - case-sensitive value you wish to search. If the `comparator` is `between` then use an array of two values to search between
     Or a set of grouped conditions has the following properties:
   - `operator` _(optional)_ - the operator used between each condition - `and`, `or`. The default is `and`
   - `conditions` _(required)_ - the array of conditions objects as described above.
@@ -293,27 +293,27 @@ Returns data from a table for one or more matching conditions. This supports gro
 	"get_attributes": ["*"],
 	"conditions": [
 		{
-			"search_attribute": "age",
-			"search_type": "between",
-			"search_value": [5, 8]
+			"attribute": "age",
+			"comparator": "between",
+			"value": [5, 8]
 		},
 		{
-			"search_attribute": "weight_lbs",
-			"search_type": "greater_than",
-			"search_value": 40
+			"attribute": "weight_lbs",
+			"comparator": "greater_than",
+			"value": 40
 		},
 		{
 			"operator": "or",
 			"conditions": [
 				{
-					"search_attribute": "adorable",
-					"search_type": "equals",
-					"search_value": true
+					"attribute": "adorable",
+					"comparator": "equals",
+					"value": true
 				},
 				{
-					"search_attribute": "lovable",
-					"search_type": "equals",
-					"search_value": true
+					"attribute": "lovable",
+					"comparator": "equals",
+					"value": true
 				}
 			]
 		}

--- a/site/versioned_docs/version-4.6/developers/operations-api/nosql-operations.md
+++ b/site/versioned_docs/version-4.6/developers/operations-api/nosql-operations.md
@@ -267,8 +267,11 @@ Returns data from a table for one or more matching conditions. This supports gro
 - `get_attributes` _(required)_ - define which attributes you want returned. Use `['*']` to return all attributes
 - `conditions` _(required)_ - the array of conditions objects, specified below, to filter by. Must include one or more object in the array that are a condition or a grouped set of conditions. A condition has the following properties:
   - `attribute` _(required)_ - the attribute you wish to search, can be any attribute.
+  - `search_attribute` - deprecated in favor of `attribute`
   - `comparator` _(required)_ - the type of search to perform - `equals`, `contains`, `starts_with`, `ends_with`, `greater_than`, `greater_than_equal`, `less_than`, `less_than_equal`, `between`
+  - `search_type` - deprecated in favor of `comparator`
   - `value` _(required)_ - case-sensitive value you wish to search. If the `comparator` is `between` then use an array of two values to search between
+  - `search_value` - deprecated in favor of `value`
     Or a set of grouped conditions has the following properties:
   - `operator` _(optional)_ - the operator used between each condition - `and`, `or`. The default is `and`
   - `conditions` _(required)_ - the array of conditions objects as described above.


### PR DESCRIPTION
`search_attribute`, `search_type`, and `search_value` have been deprecated in favor of `attribute`, `comparator`, and `value` (which have the added bonus of being consistent with the resource API)