### PR TITLE
updates to documentation and contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,13 +13,12 @@ Before contributing, please ensure you have the following installed:
 
 ```bash
 npm install
-npm run site:install
 ```
 
 2. Start the development server:
 
 ```bash
-npm run site:dev
+npm run dev
 ```
 
 3. Make and test your changes

--- a/docs/administration/cloning.md
+++ b/docs/administration/cloning.md
@@ -26,7 +26,7 @@ To start clone run `harperdb` in the CLI with either of the following variables 
 For example:
 
 ```
-HDB_LEADER_URL=https://node-1.my-domain.com:9925 REPLICATION_HOSTNAME=node-1.my-domain.com HDB_LEADER_USERNAME=... HDB_LEADER_PASSWORD=... harperdb
+HDB_LEADER_URL=https://node-1.my-domain.com:9925 REPLICATION_HOSTNAME=node-2.my-domain.com HDB_LEADER_USERNAME=... HDB_LEADER_PASSWORD=... harperdb
 ```
 
 #### Command line variables
@@ -39,7 +39,7 @@ HDB_LEADER_URL=https://node-1.my-domain.com:9925 REPLICATION_HOSTNAME=node-1.my-
 For example:
 
 ```
-harperdb --HDB_LEADER_URL https://node-1.my-domain.com:9925 --REPLICATION_HOSTNAME node-1.my-domain.com --HDB_LEADER_USERNAME ... --HDB_LEADER_PASSWORD ...
+harperdb --HDB_LEADER_URL https://node-1.my-domain.com:9925 --REPLICATION_HOSTNAME node-2.my-domain.com --HDB_LEADER_USERNAME ... --HDB_LEADER_PASSWORD ...
 ```
 
 Each time clone is run it will set a value `cloned: true` in `harperdb-config.yaml`. This value will prevent clone from
@@ -144,7 +144,7 @@ docker run -d \
   -e HDB_LEADER_PASSWORD=password \
   -e HDB_LEADER_USERNAME=admin \
   -e HDB_LEADER_URL=https://1.123.45.6:9925 \
-  -e REPLICATION_HOSTNAME=1.123.45.6 \
+  -e REPLICATION_HOSTNAME=1.123.45.7 \
   -p 9925:9925 \
   -p 9926:9926 \
   harperdb/harperdb

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -10,9 +10,9 @@ const sidebars: SidebarsConfig = {
 		{
 			type: 'category',
 			label: 'Getting Started',
-			'link': {
-				'type': 'doc',
-				'id': 'getting-started/index'
+			link: {
+				type: 'doc',
+				id: 'getting-started/index',
 			},
 			items: [
 				'getting-started/what-is-harper',

--- a/versioned_docs/version-4.4/administration/cloning.md
+++ b/versioned_docs/version-4.4/administration/cloning.md
@@ -26,7 +26,7 @@ To start clone run `harperdb` in the CLI with either of the following variables 
 For example:
 
 ```
-HDB_LEADER_URL=https://node-1.my-domain.com:9925 REPLICATION_HOSTNAME=node-1.my-domain.com HDB_LEADER_USERNAME=... HDB_LEADER_PASSWORD=... harperdb
+HDB_LEADER_URL=https://node-1.my-domain.com:9925 REPLICATION_HOSTNAME=node-2.my-domain.com HDB_LEADER_USERNAME=... HDB_LEADER_PASSWORD=... harperdb
 ```
 
 #### Command line variables
@@ -39,7 +39,7 @@ HDB_LEADER_URL=https://node-1.my-domain.com:9925 REPLICATION_HOSTNAME=node-1.my-
 For example:
 
 ```
-harperdb --HDB_LEADER_URL https://node-1.my-domain.com:9925 --REPLICATION_HOSTNAME node-1.my-domain.com --HDB_LEADER_USERNAME ... --HDB_LEADER_PASSWORD ...
+harperdb --HDB_LEADER_URL https://node-1.my-domain.com:9925 --REPLICATION_HOSTNAME node-2.my-domain.com --HDB_LEADER_USERNAME ... --HDB_LEADER_PASSWORD ...
 ```
 
 Each time clone is run it will set a value `cloned: true` in `harperdb-config.yaml`. This value will prevent clone from
@@ -144,7 +144,7 @@ docker run -d \
   -e HDB_LEADER_PASSWORD=password \
   -e HDB_LEADER_USERNAME=admin \
   -e HDB_LEADER_URL=https://1.123.45.6:9925 \
-  -e REPLICATION_HOSTNAME=1.123.45.6 \
+  -e REPLICATION_HOSTNAME=1.123.45.7 \
   -p 9925:9925 \
   -p 9926:9926 \
   harperdb/harperdb

--- a/versioned_docs/version-4.5/administration/cloning.md
+++ b/versioned_docs/version-4.5/administration/cloning.md
@@ -26,7 +26,7 @@ To start clone run `harperdb` in the CLI with either of the following variables 
 For example:
 
 ```
-HDB_LEADER_URL=https://node-1.my-domain.com:9925 REPLICATION_HOSTNAME=node-1.my-domain.com HDB_LEADER_USERNAME=... HDB_LEADER_PASSWORD=... harperdb
+HDB_LEADER_URL=https://node-1.my-domain.com:9925 REPLICATION_HOSTNAME=node-2.my-domain.com HDB_LEADER_USERNAME=... HDB_LEADER_PASSWORD=... harperdb
 ```
 
 #### Command line variables
@@ -39,7 +39,7 @@ HDB_LEADER_URL=https://node-1.my-domain.com:9925 REPLICATION_HOSTNAME=node-1.my-
 For example:
 
 ```
-harperdb --HDB_LEADER_URL https://node-1.my-domain.com:9925 --REPLICATION_HOSTNAME node-1.my-domain.com --HDB_LEADER_USERNAME ... --HDB_LEADER_PASSWORD ...
+harperdb --HDB_LEADER_URL https://node-1.my-domain.com:9925 --REPLICATION_HOSTNAME node-2.my-domain.com --HDB_LEADER_USERNAME ... --HDB_LEADER_PASSWORD ...
 ```
 
 Each time clone is run it will set a value `cloned: true` in `harperdb-config.yaml`. This value will prevent clone from
@@ -144,7 +144,7 @@ docker run -d \
   -e HDB_LEADER_PASSWORD=password \
   -e HDB_LEADER_USERNAME=admin \
   -e HDB_LEADER_URL=https://1.123.45.6:9925 \
-  -e REPLICATION_HOSTNAME=1.123.45.6 \
+  -e REPLICATION_HOSTNAME=1.123.45.7 \
   -p 9925:9925 \
   -p 9926:9926 \
   harperdb/harperdb

--- a/versioned_docs/version-4.6/administration/cloning.md
+++ b/versioned_docs/version-4.6/administration/cloning.md
@@ -26,7 +26,7 @@ To start clone run `harperdb` in the CLI with either of the following variables 
 For example:
 
 ```
-HDB_LEADER_URL=https://node-1.my-domain.com:9925 REPLICATION_HOSTNAME=node-1.my-domain.com HDB_LEADER_USERNAME=... HDB_LEADER_PASSWORD=... harperdb
+HDB_LEADER_URL=https://node-1.my-domain.com:9925 REPLICATION_HOSTNAME=node-2.my-domain.com HDB_LEADER_USERNAME=... HDB_LEADER_PASSWORD=... harperdb
 ```
 
 #### Command line variables
@@ -39,7 +39,7 @@ HDB_LEADER_URL=https://node-1.my-domain.com:9925 REPLICATION_HOSTNAME=node-1.my-
 For example:
 
 ```
-harperdb --HDB_LEADER_URL https://node-1.my-domain.com:9925 --REPLICATION_HOSTNAME node-1.my-domain.com --HDB_LEADER_USERNAME ... --HDB_LEADER_PASSWORD ...
+harperdb --HDB_LEADER_URL https://node-1.my-domain.com:9925 --REPLICATION_HOSTNAME node-2.my-domain.com --HDB_LEADER_USERNAME ... --HDB_LEADER_PASSWORD ...
 ```
 
 Each time clone is run it will set a value `cloned: true` in `harperdb-config.yaml`. This value will prevent clone from
@@ -144,7 +144,7 @@ docker run -d \
   -e HDB_LEADER_PASSWORD=password \
   -e HDB_LEADER_USERNAME=admin \
   -e HDB_LEADER_URL=https://1.123.45.6:9925 \
-  -e REPLICATION_HOSTNAME=1.123.45.6 \
+  -e REPLICATION_HOSTNAME=1.123.45.7 \
   -p 9925:9925 \
   -p 9926:9926 \
   harperdb/harperdb


### PR DESCRIPTION
Updated examples for `REPLICATION_HOSTNAME` to use a unique hostname for accuracy

removed some `npm` commands in `CONTRIBUTING.md` as they didn't seem to exist. The remaining steps seem to do what the document intended