### PR TITLE
reorder the contribution intent dropdown options so it has a better default

### DIFF
--- a/.github/ISSUE_TEMPLATE/content-issue.yml
+++ b/.github/ISSUE_TEMPLATE/content-issue.yml
@@ -62,10 +62,10 @@ body:
       label: Are you planning to fix this issue?
       description: Let us know if you'd like to contribute the fix!
       options:
+        - 'No, just reporting the issue'
+        - 'Maybe, depending on complexity'
         - "Yes, I'll submit a PR to fix this"
         - "Yes, but I'm a first-time contributor and could use guidance"
-        - 'Maybe, depending on complexity'
-        - 'No, just reporting the issue'
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/content-request.yml
+++ b/.github/ISSUE_TEMPLATE/content-request.yml
@@ -73,10 +73,10 @@ body:
       label: Are you planning to fix this issue?
       description: Let us know if you'd like to contribute the fix!
       options:
+        - 'No, just reporting the issue'
+        - 'Maybe, depending on complexity'
         - "Yes, I'll submit a PR to fix this"
         - "Yes, but I'm a first-time contributor and could use guidance"
-        - 'Maybe, depending on complexity'
-        - 'No, just reporting the issue'
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/platform-bug.yml
+++ b/.github/ISSUE_TEMPLATE/platform-bug.yml
@@ -105,10 +105,10 @@ body:
       label: Are you planning to fix this issue?
       description: Let us know if you'd like to contribute the fix!
       options:
+        - 'No, just reporting the issue'
+        - 'Maybe, depending on complexity'
         - "Yes, I'll submit a PR to fix this"
         - "Yes, but I'm a first-time contributor and could use guidance"
-        - 'Maybe, depending on complexity'
-        - 'No, just reporting the issue'
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/platform-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/platform-feature-request.yml
@@ -103,10 +103,10 @@ body:
       label: Are you planning to fix this issue?
       description: Let us know if you'd like to contribute the fix!
       options:
+        - 'No, just reporting the issue'
+        - 'Maybe, depending on complexity'
         - "Yes, I'll submit a PR to fix this"
         - "Yes, but I'm a first-time contributor and could use guidance"
-        - 'Maybe, depending on complexity'
-        - 'No, just reporting the issue'
     validations:
       required: true
 


### PR DESCRIPTION
When you create a new issue, this dropdown defaults to the first option. Some people don't realize this and accidentally indicate they are going to fix the thing being reported. I'm reording this so at least the default is "No, just reporting the issue" so someone else can fix it and its not confusing. I wish the issue template feature was more capable and we could actually require users to make a selection here 🤷‍♂️ 